### PR TITLE
Waltz-EPICS integration demo

### DIFF
--- a/apps/tango_webapp/index.html
+++ b/apps/tango_webapp/index.html
@@ -26,6 +26,8 @@
 <!-- JQuery -->
 <script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.0/jquery.min.js"></script>
 
+<script src="/epics2web/resources/js/epics2web.js" type="application/javascript"></script>
+
 <script type="application/javascript" src="../../jmvc/include.js?tango_webapp,development"></script>
 <script type="module" src="main.js"></script>
 </body>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
-version: '3.2'
+version: '3.7'
+
 services:
+  epics-sim:
+    image: lnlssol/epics-sim
+    entrypoint: /root/runIocsFG.sh
   tango-db:
     image: tangocs/mysql:9.2.2
     ports:
@@ -7,7 +11,7 @@ services:
     environment:
     - MYSQL_ROOT_PASSWORD=root
   tango-cs:
-    image: ingvord/tango-cs-with-rest:1.14
+    image: ingvord/tango-cs-with-rest
     ports:
     - "10000:10000"
     - "10001:10001"
@@ -26,11 +30,12 @@ services:
     depends_on:
     - tango-cs
   tango-epics:
-    image: ingvord/tango-epics:9.2.5-with-starter
+    image: ingvord/tango-epics
     environment:
     - TANGO_HOST=tango-cs:10000
     depends_on:
     - tango-cs
+    - epics-sim
   waltz:
     image: tangocs/waltz:v0.7.3
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,27 @@
 version: '3.7'
 
+networks:
+  public_net:
+    driver: bridge
+    ipam:
+      config:
+      - subnet: 192.168.0.0/24
+      driver: default
+
 services:
   epics-sim:
     image: lnlssol/epics-sim
     entrypoint: /root/runIocsFG.sh
+    networks:
+      public_net:
+        ipv4_address: 192.168.0.10
   tango-db:
     image: tangocs/mysql:9.2.2
-    ports:
-    - "9999:3306"
     environment:
     - MYSQL_ROOT_PASSWORD=root
+    networks:
+      public_net:
+        ipv4_address: 192.168.0.20
   tango-cs:
     image: ingvord/tango-cs-with-rest
     ports:
@@ -23,12 +35,18 @@ services:
     - MYSQL_DATABASE=tango
     depends_on:
     - tango-db
+    networks:
+      public_net:
+        ipv4_address: 192.168.0.30
   tango-test:
     image: tangocs/tango-test
     environment:
     - TANGO_HOST=tango-cs:10000
     depends_on:
     - tango-cs
+    networks:
+      public_net:
+        ipv4_address: 192.168.0.40
   tango-epics:
     image: ingvord/tango-epics
     environment:
@@ -36,7 +54,39 @@ services:
     depends_on:
     - tango-cs
     - epics-sim
+    networks:
+      public_net:
+        ipv4_address: 192.168.0.50
+  epics2web:
+    image: ingvord/epics2web
+    expose:
+    - "8080"
+    environment:
+    - EPICS_CA_ADDR_LIST=192.168.0.255
+    depends_on:
+    - epics-sim
+    networks:
+      public_net:
+        ipv4_address: 192.168.0.11
   waltz:
-    image: tangocs/waltz:v0.7.3
+    build: .
+    expose:
+    - "8080"
+    networks:
+      public_net:
+        ipv4_address: 192.168.0.22
+  haproxy:
+    build: ./haproxy
+    environment:
+      EPICS2WEB_IP: 192.168.0.11
+      WALTZ_IP: 192.168.0.22
     ports:
-      - "8080:8080"
+    - "8080:8080"
+    networks:
+      public_net:
+        ipv4_address: 192.168.0.100
+    depends_on:
+    - epics2web
+    - waltz
+
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
     driver: bridge
     ipam:
       config:
-      - subnet: 192.168.0.0/24
+      - subnet: 192.169.0.0/24
       driver: default
 
 services:
@@ -14,14 +14,14 @@ services:
     entrypoint: /root/runIocsFG.sh
     networks:
       public_net:
-        ipv4_address: 192.168.0.10
+        ipv4_address: 192.169.0.10
   tango-db:
     image: tangocs/mysql:9.2.2
     environment:
     - MYSQL_ROOT_PASSWORD=root
     networks:
       public_net:
-        ipv4_address: 192.168.0.20
+        ipv4_address: 192.169.0.20
   tango-cs:
     image: ingvord/tango-cs-with-rest
     ports:
@@ -37,7 +37,7 @@ services:
     - tango-db
     networks:
       public_net:
-        ipv4_address: 192.168.0.30
+        ipv4_address: 192.169.0.30
   tango-test:
     image: tangocs/tango-test
     environment:
@@ -46,7 +46,7 @@ services:
     - tango-cs
     networks:
       public_net:
-        ipv4_address: 192.168.0.40
+        ipv4_address: 192.169.0.40
   tango-epics:
     image: ingvord/tango-epics
     environment:
@@ -56,35 +56,35 @@ services:
     - epics-sim
     networks:
       public_net:
-        ipv4_address: 192.168.0.50
+        ipv4_address: 192.169.0.50
   epics2web:
     image: ingvord/epics2web
     expose:
     - "8080"
     environment:
-    - EPICS_CA_ADDR_LIST=192.168.0.255
+    - EPICS_CA_ADDR_LIST=192.169.0.255
     depends_on:
     - epics-sim
     networks:
       public_net:
-        ipv4_address: 192.168.0.11
+        ipv4_address: 192.169.0.11
   waltz:
     image: ingvord/waltz:epics-demo-29082019
     expose:
     - "8080"
     networks:
       public_net:
-        ipv4_address: 192.168.0.22
+        ipv4_address: 192.169.0.22
   haproxy:
     build: ./haproxy
     environment:
-      EPICS2WEB_IP: 192.168.0.11
-      WALTZ_IP: 192.168.0.22
+      EPICS2WEB_IP: 192.169.0.11
+      WALTZ_IP: 192.169.0.22
     ports:
     - "8080:8080"
     networks:
       public_net:
-        ipv4_address: 192.168.0.100
+        ipv4_address: 192.169.0.100
     depends_on:
     - epics2web
     - waltz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       public_net:
         ipv4_address: 192.168.0.11
   waltz:
-    build: .
+    image: ingvord/waltz:epics-demo-29082019
     expose:
     - "8080"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,12 @@ services:
     - TANGO_HOST=tango-cs:10000
     depends_on:
     - tango-cs
+  tango-epics:
+    image: ingvord/tango-epics:9.2.5-with-starter
+    environment:
+    - TANGO_HOST=tango-cs:10000
+    depends_on:
+    - tango-cs
   waltz:
     image: tangocs/waltz:v0.7.3
     ports:

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,0 +1,2 @@
+FROM haproxy:alpine
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -1,0 +1,16 @@
+global
+    maxconn 1000
+defaults
+    timeout connect 10s
+    timeout client 30s
+    timeout server 30s
+    mode http
+frontend localhost
+    bind :8080
+    use_backend epics2web if { path_beg /epics2web }
+    use_backend waltz     if { path_beg /waltz } 
+backend epics2web
+    server tomcat ${EPICS2WEB_IP}:8080
+backend waltz
+    server tomcat ${WALTZ_IP}:8080
+    

--- a/resources/webix_widgets/epics_monitor_tab.js
+++ b/resources/webix_widgets/epics_monitor_tab.js
@@ -1,0 +1,164 @@
+function connectEpics2Web() {
+    return new Promise(function (resolve, reject) {
+        try {
+            const connection = new jlab.epics2web.ClientConnection();
+            connection.onopen = function () {
+                webix.message("Connection to Epics2Web is open!");
+                resolve(connection);
+            };
+            connection.onerror = function (err) {
+                reject(err);
+            };
+            connection.onclose = function () {
+                reject(new Error("Connection to Epics2Web is closed!"));
+            };
+        } catch (e) {
+            reject(e);
+        }
+    });
+}
+
+export const EpicsMonitorController = class extends MVC.Controller {
+    buildUI(platform_api) {
+        platform_api.ui_builder.add_mainview_item(newEpicsMonitorTab());
+    }
+
+    /**
+     *
+     * @param {PlatformApi} platform_api
+     */
+    async initialize(platform_api) {
+        const $$hq = $$('epics');
+        const $$datatable = $$hq.$$('datatable');
+
+
+        $$datatable.epics2web = connectEpics2Web().then(conn => {
+            conn.addEventListener('info', ({detail: {pv, connected, datatype, labels}}) => {
+                $$datatable.updateItem(pv, {
+                    status: connected,
+                    datatype
+                });
+            });
+
+            conn.addEventListener('update', ({detail: {pv, value, date}}) => {
+                $$datatable.updateItem(pv, {
+                    value,
+                    date
+                });
+            });
+            return conn;
+        }).catch(err => {
+            TangoWebappHelpers.error("Failed to connect to Epics2Web!", err);
+        });
+
+        $$datatable.add({
+            id: 'IOC:m1',
+            status: 'UNKNOWN'
+        });
+    }
+};
+
+//disable Xenv widget for master
+EpicsMonitorController.initialize();
+
+const epics_datatable = webix.protoUI({
+    name: 'epics_datatable',
+    epics2web: null,
+    _config() {
+        return {
+            columns: [
+                {id: 'id'},
+                {
+                    id: 'status', template(obj) {
+                        if (obj.status !== undefined)
+                            return obj.status ? "CONNECTED" : "DISCONNECTED";
+
+                    }
+                },
+                {id: 'datatype'},
+                {id: 'value'},
+                {id: 'date', fillspace: true},
+                {
+                    id: "remove", width: 25, header: "", template() {
+                        return '<span class="webix_icon remove fa-trash"></span>'
+                    }
+                }
+            ],
+            on: {
+                onAfterAdd(id) {
+                    this.epics2web.then(conn => {
+                        conn.monitorPvs([id])
+                    });
+                },
+                onAfterDelete(id) {
+                    this.epics2web.then(conn => {
+                        conn.clearPvs([id])
+                    });
+                }
+            }
+        }
+    },
+    $init(config) {
+        webix.extend(config, this._config());
+    },
+    defaults: {
+        resizeColumn: true
+    }
+}, webix.ui.datatable);
+
+function newEpicsDatatable(config = {}) {
+    return webix.extend({
+        id: 'datatable',
+        view: 'epics_datatable',
+        onClick: {
+            "remove"(event, cell, target) {
+                this.remove(cell.row)
+            }
+        }
+    }, config);
+}
+
+const epics_monitor = webix.protoUI({
+    name: "epics_monitor",
+    _ui() {
+        return {
+            rows: [
+                {
+                    //TODO header
+                    maxHeight: 25,
+                    view: 'form',
+                    id: 'form',
+                    cols: [
+                        {view: 'text', name: 'id', placeholder: 'EPICS PV name'},
+                        {
+                            view: 'button', type: "icon", icon: "save", value: 'Add', maxWidth: 40, click() {
+                                this.getFormView().save();
+                            }
+                        }
+                    ]
+
+                },
+                newEpicsDatatable()
+            ]
+        }
+    },
+    $init(config) {
+        webix.extend(config, this._ui());
+
+        this.$ready.push(() => {
+            this.$$('form').bind(this.$$('datatable'));
+        });
+    }
+}, webix.IdSpace, webix.ui.layout);
+
+export function newEpicsMonitorTab() {
+    return {
+        header: "<span class='webix_icon fa-feed'></span> EPICS monitor",
+        borderless: true,
+        body:
+            {
+                id: 'epics',
+                view: "epics_monitor"
+            }
+    }
+}

--- a/resources/webix_widgets/epics_monitor_tab.js
+++ b/resources/webix_widgets/epics_monitor_tab.js
@@ -94,7 +94,15 @@ const epics_datatable = webix.protoUI({
                     this.epics2web.then(conn => {
                         conn.clearPvs([id])
                     });
+                },
+                onBeforeDrop(context) {
+                    return this === context.from ||
+                        context.from.config.$id === 'attrs';
+
                 }
+            },
+            externalData: function (data, id) {
+                return {id: data.name.replace(/_/g, ':')};
             }
         }
     },
@@ -102,7 +110,9 @@ const epics_datatable = webix.protoUI({
         webix.extend(config, this._config());
     },
     defaults: {
-        resizeColumn: true
+        resizeColumn: true,
+        drag: true,
+        dragColumn: true
     }
 }, webix.ui.datatable);
 
@@ -142,6 +152,9 @@ const epics_monitor = webix.protoUI({
             ]
         }
     },
+    monitorPv(pv) {
+        this.$$('datatable').add({id: pv})
+    },
     $init(config) {
         webix.extend(config, this._ui());
 
@@ -149,7 +162,7 @@ const epics_monitor = webix.protoUI({
             this.$$('form').bind(this.$$('datatable'));
         });
     }
-}, webix.IdSpace, webix.ui.layout);
+}, webix.DragControl, webix.IdSpace, webix.ui.layout);
 
 export function newEpicsMonitorTab() {
     return {

--- a/resources/webix_widgets/epics_monitor_tab.js
+++ b/resources/webix_widgets/epics_monitor_tab.js
@@ -120,13 +120,14 @@ const epics_datatable = webix.protoUI({
                     });
                 },
                 onBeforeDrop(context) {
-                    return this === context.from ||
-                        context.from.config.$id === 'attrs';
-
+                    if (this === context.from) return true;
+                    else if (context.from.config.$id === 'attrs')
+                        context.from.copy(context.start, this.count(), this, {newId: context.start.substring(context.start.lastIndexOf('/') + 1).replace(/_/g, ":")});
+                    return false;
                 }
             },
             externalData: function (data, id) {
-                return {id: data.name.replace(/_/g, ':')};
+                return {id};
             }
         }
     },

--- a/resources/webix_widgets/import.js
+++ b/resources/webix_widgets/import.js
@@ -37,3 +37,4 @@ import "./astor_view.js";
 import "./table_widget.js";
 import "./plotly_widget.js";
 import "./dashboard_widget.js";
+import "./epics_monitor_tab.js";


### PR DESCRIPTION
This PR contains docker compose that assembles the whole stack for Waltz to EPICS integration including [TangoEpics](https://github.com/Ingvord/tango-epics-docker)  and [Epics2Web](https://github.com/Ingvord/docker-epics2web).

It also includes a simple EPICS monitor widget:

![Peek 2019-08-29 17-05](https://user-images.githubusercontent.com/11678364/63947279-4c396d00-ca7f-11e9-9236-56f93798e946.gif)

**Getting started**:

Launch docker compose using `docker-compose up --build` command

Docker engine 1.18> is required due to EPICS-CA broadcasting

![docker-compose](https://user-images.githubusercontent.com/11678364/64256414-ba6cac80-cf23-11e9-9110-8a393722f6a5.png)


**Acknowledgements**

Many thanks to 

@jairomoldes for [TangoEpics](https://www.tango-controls.org/developers/dsc/ds/327/)
@slominskir for [Epics2Web CA Gateway](https://github.com/JeffersonLab/epics2web)