### PR TITLE
Allow combination of multiple profiles in XenvHQ widget

### DIFF
--- a/models/platform/tango_rest_api_request.js
+++ b/models/platform/tango_rest_api_request.js
@@ -252,6 +252,12 @@ TangoWebappPlatform.TangoRestApiRequest = MVC.Model.extend('tango_rest_api_reque
             return this;
         },
 
+        value: function () {
+            //TODO check devices branch
+            this.url += '/value';
+            return this;
+        },
+
         /**
          * Fires event to OpenAjax
          * @fires tango_webapp.rest_success

--- a/resources/webix_widgets/import.js
+++ b/resources/webix_widgets/import.js
@@ -37,3 +37,4 @@ import "./astor_view.js";
 import "./table_widget.js";
 import "./plotly_widget.js";
 import "./dashboard_widget.js";
+import "./xenv.js";

--- a/resources/webix_widgets/xenv.js
+++ b/resources/webix_widgets/xenv.js
@@ -25,6 +25,24 @@ function newXenvSVGTab(){
     }
 }
 
+export function newTangoAttributeProxy(rest, host, device, attr) {
+    return {
+        $proxy: true,
+        load(view, params) {
+            view.clearAll();
+            view.parse(rest.request().hosts(host).devices(device).attributes(attr).value().get()
+                .then(value => JSON.parse(value.value))
+                .catch(err => TangoWebappHelpers.error(err)));
+        },
+        save(view, params, dp) {
+            //TODO
+        },
+        result() {
+
+        }
+    };
+}
+
 export const XenvHqController = class extends MVC.Controller {
     buildUI(platform_api) {
         // platform_api.ui_builder.add_mainview_item(newXenvSVGTab());

--- a/resources/webix_widgets/xenv.js
+++ b/resources/webix_widgets/xenv.js
@@ -84,7 +84,7 @@ XenvHqController.initialize();
 
 const xenvHq = webix.protoUI({
     name: "xenv-hq",
-    profile: new webix.DataRecord(),
+    profile: null,
     async applySettings(){
         for(const server of kServers){
             if(this.$$(kServerFieldMap[server]).getValue()) {
@@ -366,19 +366,16 @@ const xenvHq = webix.protoUI({
         this._init(config);
 
         webix.extend(config, this._ui());
-
-        this.$ready.push(()=> {
-            this.$$('main_tab').servers.data.sync(this.servers);
+        this.profile = new webix.DataRecord({
+            on: {
+                onAfterLoad:()=>{
+                    this.$$('main_tab').applyProfile(this.profile.getValues());
+                }
+            }
         });
 
         this.$ready.push(()=> {
             this.$$('profile').bind(this.$$('profiles'));
-        });
-
-        this.$ready.push(()=> {
-            this.profile.waitData.then(() => {
-                this.$$('main_tab').applyProfile(this.profile.getValues());
-            });
         });
 
         this.addDrop(this.getNode(),{

--- a/resources/webix_widgets/xenv.js
+++ b/resources/webix_widgets/xenv.js
@@ -27,7 +27,7 @@ function newXenvSVGTab(){
 
 export const XenvHqController = class extends MVC.Controller {
     buildUI(platform_api) {
-        platform_api.ui_builder.add_mainview_item(newXenvSVGTab());
+        // platform_api.ui_builder.add_mainview_item(newXenvSVGTab());
         platform_api.ui_builder.add_mainview_item(newXenvHeadQuarterTab());
     }
     /**
@@ -61,7 +61,7 @@ export const XenvHqController = class extends MVC.Controller {
 };
 
 //disable Xenv widget for master
-// XenvHqController.initialize();
+XenvHqController.initialize();
 
 const xenvHq = webix.protoUI({
     name: "xenv-hq",

--- a/resources/webix_widgets/xenv.js
+++ b/resources/webix_widgets/xenv.js
@@ -140,12 +140,17 @@ const xenvHq = webix.protoUI({
             return;
         }
 
+
+        const collections = this.$$('main_tab').prepareCollections();
+
+        const updateProfileCollections = await this.main.device.fetchCommand("updateProfileCollections");
         const stopAll = await this.main.device.fetchCommand("stopAll");
         const clearAll = await this.main.device.fetchCommand("clearAll");
         const updateAll = await this.main.device.fetchCommand("updateAll");
         const startAll = await this.main.device.fetchCommand("startAll");
 
-        TangoWebapp.UserAction.executeCommand(stopAll)
+        TangoWebapp.UserAction.executeCommand(updateProfileCollections, collections)
+        .then(() => TangoWebapp.UserAction.executeCommand(stopAll))
         .then(() => TangoWebapp.UserAction.executeCommand(clearAll))
         .then(() => TangoWebapp.UserAction.executeCommand(updateAll))
         .then(() => TangoWebapp.UserAction.executeCommand(startAll));

--- a/resources/webix_widgets/xenv.js
+++ b/resources/webix_widgets/xenv.js
@@ -383,6 +383,10 @@ const xenvHq = webix.protoUI({
             this.$$('profile').bind(this.$$('profiles'));
         });
 
+        this.$ready.push(()=> {
+            this.$$('main_tab').servers.sync(this.servers);
+        });
+
         this.addDrop(this.getNode(),{
             /**
              * @function

--- a/resources/webix_widgets/xenv_datasources_view.js
+++ b/resources/webix_widgets/xenv_datasources_view.js
@@ -356,7 +356,7 @@ const datasources_view = webix.protoUI({
             .value().put("?v=" + collection)
             .then(() => {
                 this.datasources.load(
-                    newTangoAttributeProxy(PlatformContext.rest, "localhost/10000", "development/xenv/configuration", "datasources")
+                    newTangoAttributeProxy(PlatformContext.rest, this.config.host, this.config.device, "datasources")
                 );
             })
             .catch(err => TangoWebappHelpers.error(err));
@@ -371,14 +371,14 @@ const datasources_view = webix.protoUI({
             .value().put("?v=" + collection)
     },
     deleteCollection(collection){
-        return this.config.rest.request()
+        return PlatformContext.rest.request()
             .hosts(this.config.host)
             .devices(this.config.device)
             .commands('deleteCollection')
             .put("", collection);
     },
     cloneCollection(collection, source){
-        return this.config.rest.request()
+        return PlatformContext.rest.request()
             .hosts(this.config.host)
             .devices(this.config.device)
             .commands('cloneCollection')
@@ -387,7 +387,7 @@ const datasources_view = webix.protoUI({
     processDataSource(operation, dataSource){
         return this.setCollection()
             .then(() => {
-                return this.config.rest.request()
+                return PlatformContext.rest.request()
                     .hosts(this.config.host)
                     .devices(this.config.device)
                     .commands(`${operation}datasource`)//insert|update|delete
@@ -442,7 +442,6 @@ const datasources_view = webix.protoUI({
 
         OpenAjax.hub.subscribe(`ConfigurationManager.set.proxy`,(eventName,{server})=>{
             webix.extend(this.config, {
-                rest: PlatformContext.rest,
                 host: server.device.host.id.replace(':','/'),
                 device: server.ver
             });

--- a/resources/webix_widgets/xenv_datasources_view.js
+++ b/resources/webix_widgets/xenv_datasources_view.js
@@ -1,0 +1,228 @@
+/**
+ *
+ * @author Igor Khokhriakov <igor.khokhriakov@hzg.de>
+ * @since 04.09.2019
+ */
+
+import newSearch from "./search.js";
+
+/**
+ *
+ *
+ * @param {DataSource} dataSource
+ * @param {string} value
+ * @function
+ */
+const filterDataSourcesList = (dataSource, value)=>{
+    if(!value) return true;
+    return dataSource.src.includes(value) || dataSource.nxPath.includes(value);
+};
+
+function newDataSourceForm(parent){
+    return {
+        view: "form",
+        id: "frmDataSource",
+        on:{
+            onBindApply(obj){
+                if(!obj) return;
+                this.setValues({
+                    srcScheme:this.elements['srcScheme'].getList().find(option => obj.src.startsWith(option.value), true).value,
+                    srcPath  : obj.src.substring(obj.src.indexOf(':') + 1)
+                }, true);
+            },
+            onBeforeValidate(){
+                this.setValues({
+                    src: `${this.elements['srcScheme'].getValue()}${this.elements['srcPath'].getValue()}`
+                },true);
+            }
+        },
+        elements: [
+            {cols:[
+                    { view: "label", label: "src", maxWidth: 80 },
+                    {view: "combo", name: "srcScheme", maxWidth: 120, options: [
+                            "tine:", "tango:", "predator:", "external:"
+                        ], validate: webix.rules.isNotEmpty},
+                    {view: "text", name: "srcPath"},
+                ]},
+            {view: "text", name: "nxPath", label: "nxPath", validate: webix.rules.isNotEmpty},
+            {
+                view: "radio", name: "type", label: "type", options: [
+                    "scalar", "spectrum", "log"
+                ], validate: webix.rules.isNotEmpty
+            },
+            {view: "text", name: "pollRate", label: "pollRate", validate: webix.rules.isNumber},
+            {
+                view: "select", name: "dataType", label: "dataType", options: [
+                    "string", "int16", "int32", "int64", "uint16", "uint32", "uint64", "float32", "float64"
+                ]
+            },
+            {
+                cols: [
+                    {},
+                    {
+                        view: "button", width: 30, type: "icon", icon: "save", tooltip: "save", click: obj => {
+                            parent.$$('frmDataSource').save();
+                        }
+                    },
+                    {
+                        view: "button", width: 30, type: "icon", icon: "clone", tooltip: "clone", click: obj => {
+                            if(!parent.$$('frmDataSource').validate()) return;
+
+                            const cloned = parent.$$('frmDataSource').getValues();
+                            cloned._id = webix.uid();
+
+                            parent.$$('listDataSources').add(cloned);
+                        }
+                    },
+                    {
+                        view: "button", width: 30, type: "icon", icon: "trash", tooltip: "delete", click: obj => {
+                            const $$frm = parent.$$('frmDataSource');
+                            const id = $$frm.getValues()._id;
+                            $$frm.clear();
+                            parent.$$('listDataSources').remove(id);
+                        }
+                    }
+                ]
+            }
+        ]
+    };
+}
+
+function newDataSourcesList(parent){
+    return {
+        view: "list",
+        id: "listDataSources",
+        template:
+            "<span class='webix_strong'>Src: </span>#src#<br/>" +
+            "<span class='webix_strong'>nxPath: </span>#nxPath#",
+        gravity: 4,
+        type: {
+            height: "auto"
+        },
+        scheme:{
+            // add
+            $init(obj){
+                obj.id = obj._id;//copy mongodb _id
+            }
+        },
+        on: {
+            onItemClick(id){
+                if(this.getSelectedId() === id){
+                    this.unselectAll();
+                } else {
+                    this.select(id);
+                }
+            },
+            onBlur(){
+                // $$hq.pushConfiguration();
+            },
+            onAfterAdd: function (id) {
+                parent.addDataSource(this.getItem(id));
+            },
+            onDataUpdate: function (id) {
+                parent.updateDataSource(this.getItem(id));
+            },
+            onBeforeDelete: function (id) {
+                parent.removeDataSource(this.getItem(id));
+            }
+        }
+    };
+}
+
+function newDataSourceCollectionsProxy(rest, host, device) {
+    return {
+        $proxy: true,
+        load(view, params) {
+            return rest.request().hosts(host).devices(device).attributes("datasourcecollections").value().get()
+                .then(value => JSON.parse(value.value))
+                .catch(err => TangoWebappHelpers.error(err))//TODO return error?
+        },
+        save(view, params, dp) {
+
+        },
+        result() {
+
+        }
+    };
+}
+
+const datasources_view = webix.protoUI({
+    name: "datasources_view",
+    collections: new webix.DataCollection(),
+    datasources: new webix.DataCollection(),
+    _ui(){
+        return {
+            rows:[
+                {
+                    view:"toolbar",
+                    cols:[
+                        {
+                            view:"richselect",
+                            id: "selectDataSources",
+                            options:[]
+                        },
+                        {}
+                    ]
+                },
+                newSearch("listDataSources", filterDataSourcesList),
+                newDataSourcesList(this),
+                newDataSourceForm(this)
+            ]
+        }
+    },
+    async addDataSource(dataSource){
+        const collection = this.$$("selectDataSources").getValue();
+
+        const cmd = await this.config.configurationManager.device.fetchCommand("addDataSource");
+        UserAction.executeCommand(cmd, [collection,JSON.stringify(dataSource)]).then(()=> {
+            this.datasources.getItem(collection).data.push(dataSource);
+            this.datasources.setCursor(collection);
+        }).fail(err => TangoWebappHelpers.error(err));
+    },
+    async updateDataSource(dataSource){
+        const collection = this.$$("selectDataSources").getValue();
+
+        const cmd = await this.config.configurationManager.device.fetchCommand("updateDataSource");
+        UserAction.executeCommand(cmd, [collection,JSON.stringify(dataSource)]).then(()=> {
+            this.datasources.getItem(collection).data.push(dataSource);
+            this.datasources.setCursor(collection);
+        }).fail(err => TangoWebappHelpers.error(err));
+    },
+    $init(config){
+        webix.extend(config,this._ui());
+
+        this.$ready.push(() => {
+            this.collections.define({url: newDataSourceCollectionsProxy(PlatformContext.rest,"localhost/10000", "development/xenv/configuration")});
+
+            this.collections.load("");
+            // this.collections.parse(PlatformContext.rest.request().hosts("localhost:10000").devices("development/xenv/configuration").attrs("datasourcecollections").get()
+            //     .then(value => JSON.parse(value.value))
+            //     .catch(err => TangoWebappHelpers.error(err)));
+
+            const list = this.$$("selectDataSources").getPopup().getList();
+
+            list.define("template", "#id#");
+
+            list.attachEvent("onAfterSelect", id => {
+                PlatformContext.rest.request().hosts("localhost:10000").devices("development/xenv/configuration").attrs("datasourcescollection").put(id)
+                    .then(() => {
+                        this.datasources.parse(PlatformContext.rest.request().hosts("localhost:10000").devices("development/xenv/configuration").attrs("datasourcescollection").get()
+                            .then(value => JSON.parse(value.value))
+                            .catch(err => TangoWebappHelpers.error(err)));
+                    })
+                    .catch(err => TangoWebappHelpers.error(err));
+            });
+            list.sync(this.collections);
+
+            this.$$("listDataSources").sync(this.datasources);
+            this.$$("frmDataSource").bind(this.$$("listDataSources"));
+        });
+    }
+},webix.IdSpace, webix.ui.layout);
+
+export function newDataSourcesBody(config){
+    return webix.extend({
+        view: "datasources_view",
+        id:"datasources_view_tab"
+    },config);
+}

--- a/resources/webix_widgets/xenv_datasources_view.js
+++ b/resources/webix_widgets/xenv_datasources_view.js
@@ -371,11 +371,22 @@ const datasources_view = webix.protoUI({
             .value().put("?v=" + collection)
     },
     deleteCollection(collection){
-        return PlatformContext.rest.request()
+        return new webix.promise(function(success, fail){
+            webix.modalbox({
+                buttons:["No", "Yes"],
+                width:500,
+                text:`<span class='webix_icon fa-exclamation-circle'></span><p>This will delete data sources collection ${collection} and all associated data sources! Proceed?</p>`,
+                callback:function(result){
+                    if (result === "1") success();
+                }
+            });
+        }).then(() => {
+            return PlatformContext.rest.request()
             .hosts(this.config.host)
             .devices(this.config.device)
             .commands('deleteCollection')
-            .put("", collection);
+            .put("", collection);}
+        );
     },
     cloneCollection(collection, source){
         return PlatformContext.rest.request()

--- a/resources/webix_widgets/xenv_datasources_view.js
+++ b/resources/webix_widgets/xenv_datasources_view.js
@@ -61,7 +61,11 @@ function newDataSourceForm(parent){
                     {},
                     {
                         view: "button", width: 30, type: "icon", icon: "save", tooltip: "save", click: obj => {
-                            parent.$$('frmDataSource').save();
+                            const $$form = parent.$$('frmDataSource');
+                            $$form.save();
+                            //reset form, so it will be counted as unsaved
+                            if ($$form.setDirty)
+                                $$form.setDirty(true);
                         }
                     },
                     {
@@ -69,17 +73,17 @@ function newDataSourceForm(parent){
                             if(!parent.$$('frmDataSource').validate()) return;
 
                             const cloned = parent.$$('frmDataSource').getValues();
-                            cloned._id = webix.uid();
+                            cloned.id = webix.uid();
 
-                            parent.$$('listDataSources').add(cloned);
+                            parent.datasources.add(cloned);
                         }
                     },
                     {
                         view: "button", width: 30, type: "icon", icon: "trash", tooltip: "delete", click: obj => {
                             const $$frm = parent.$$('frmDataSource');
-                            const id = $$frm.getValues()._id;
+                            const id = $$frm.getValues().id;
                             $$frm.clear();
-                            parent.$$('listDataSources').remove(id);
+                            parent.datasources.remove(id);
                         }
                     }
                 ]
@@ -113,6 +117,9 @@ function newDataSourcesList(parent){
                     this.select(id);
                 }
             },
+            onAfterSelect(id){
+                parent.datasources.setCursor(id);
+            },
             onBlur(){
                 // $$hq.pushConfiguration();
             },
@@ -129,22 +136,40 @@ function newDataSourcesList(parent){
     };
 }
 
-function newDataSourceCollectionsProxy(rest, host, device) {
+function newTangoAttributeProxy(rest, host, device, attr) {
     return {
         $proxy: true,
         load(view, params) {
-            return rest.request().hosts(host).devices(device).attributes("datasourcecollections").value().get()
+            view.clearAll();
+            view.parse(rest.request().hosts(host).devices(device).attributes(attr).value().get()
                 .then(value => JSON.parse(value.value))
-                .catch(err => TangoWebappHelpers.error(err))//TODO return error?
+                .catch(err => TangoWebappHelpers.error(err)));
         },
         save(view, params, dp) {
-
+            //TODO
         },
         result() {
 
         }
     };
 }
+
+const dataSourcesProxy = {
+        $proxy: true,
+        load(view, params) {
+            //TODO
+        },
+        save(view, params, dp) {
+            switch (params.operations) {
+                case "insert":
+                    
+            }
+        },
+        result() {
+
+        }
+}
+
 
 const datasources_view = webix.protoUI({
     name: "datasources_view",
@@ -173,49 +198,76 @@ const datasources_view = webix.protoUI({
     async addDataSource(dataSource){
         const collection = this.$$("selectDataSources").getValue();
 
-        const cmd = await this.config.configurationManager.device.fetchCommand("addDataSource");
-        UserAction.executeCommand(cmd, [collection,JSON.stringify(dataSource)]).then(()=> {
-            this.datasources.getItem(collection).data.push(dataSource);
-            this.datasources.setCursor(collection);
-        }).fail(err => TangoWebappHelpers.error(err));
+        // const cmd = await this.config.configurationManager.device.fetchCommand("addDataSource");
+        // UserAction.executeCommand(cmd, [collection,JSON.stringify(dataSource)]).then(()=> {
+        //     this.datasources.getItem(collection).data.push(dataSource);
+        //     this.datasources.setCursor(collection);
+        // }).fail(err => TangoWebappHelpers.error(err));
     },
     async updateDataSource(dataSource){
         const collection = this.$$("selectDataSources").getValue();
 
-        const cmd = await this.config.configurationManager.device.fetchCommand("updateDataSource");
-        UserAction.executeCommand(cmd, [collection,JSON.stringify(dataSource)]).then(()=> {
-            this.datasources.getItem(collection).data.push(dataSource);
-            this.datasources.setCursor(collection);
-        }).fail(err => TangoWebappHelpers.error(err));
+        // const cmd = await this.config.configurationManager.device.fetchCommand("updateDataSource");
+        // UserAction.executeCommand(cmd, [collection,JSON.stringify(dataSource)]).then(()=> {
+        //     this.datasources.getItem(collection).data.push(dataSource);
+        //     this.datasources.setCursor(collection);
+        // }).fail(err => TangoWebappHelpers.error(err));
     },
     $init(config){
         webix.extend(config,this._ui());
 
         this.$ready.push(() => {
-            this.collections.define({url: newDataSourceCollectionsProxy(PlatformContext.rest,"localhost/10000", "development/xenv/configuration")});
 
-            this.collections.load("");
-            // this.collections.parse(PlatformContext.rest.request().hosts("localhost:10000").devices("development/xenv/configuration").attrs("datasourcecollections").get()
-            //     .then(value => JSON.parse(value.value))
-            //     .catch(err => TangoWebappHelpers.error(err)));
+
+            // this.collections.load();
+
+            this.collections = new webix.DataCollection({
+                url: newTangoAttributeProxy(PlatformContext.rest, "localhost/10000", "development/xenv/configuration", "datasourcecollections")
+            });
+
+
+            this.datasources = new webix.DataCollection(
+
+            );
+
+            const dp = new webix.DataProcessor({
+                url: {
+                    $proxy: true,
+                    save(view, params, dp){
+                        return dp.config.rest.request()
+                            .hosts(dp.config.host)
+                            .devices(dp.config.device)
+                            .commands(`${params.operation}datasource`)//insert|update|delete
+                            .put("", params.data);
+                    }
+                },
+                master: this.datasources,
+                rest: PlatformContext.rest,
+                host: "localhost/10000",
+                device: "development/xenv/configuration"
+
+            });
+
 
             const list = this.$$("selectDataSources").getPopup().getList();
 
             list.define("template", "#id#");
 
             list.attachEvent("onAfterSelect", id => {
-                PlatformContext.rest.request().hosts("localhost:10000").devices("development/xenv/configuration").attrs("datasourcescollection").put(id)
+                PlatformContext.rest.request().hosts("localhost/10000").devices("development/xenv/configuration").attributes("datasourcescollection").value().put("?v=" + id)
                     .then(() => {
-                        this.datasources.parse(PlatformContext.rest.request().hosts("localhost:10000").devices("development/xenv/configuration").attrs("datasourcescollection").get()
-                            .then(value => JSON.parse(value.value))
-                            .catch(err => TangoWebappHelpers.error(err)));
+                        this.datasources.load(
+                            newTangoAttributeProxy(PlatformContext.rest, "localhost/10000", "development/xenv/configuration", "datasources")
+                        );
                     })
                     .catch(err => TangoWebappHelpers.error(err));
             });
             list.sync(this.collections);
 
+
+
             this.$$("listDataSources").sync(this.datasources);
-            this.$$("frmDataSource").bind(this.$$("listDataSources"));
+            this.$$("frmDataSource").bind(this.datasources);
         });
     }
 },webix.IdSpace, webix.ui.layout);

--- a/resources/webix_widgets/xenv_datasources_view.js
+++ b/resources/webix_widgets/xenv_datasources_view.js
@@ -479,6 +479,14 @@ const datasources_view = webix.protoUI({
                 return false;
             }.bind(this)
         });
+    },
+    defaults: {
+        on: {
+            onViewShow() {
+                if (this.config.configurationManager.device == null) return;
+                this.collections.load(newTangoAttributeProxy(PlatformContext.rest, this.config.host, this.config.device, "datasourcecollections"));
+            }
+        }
     }
 }, webix.DragControl, webix.IdSpace, webix.ui.layout);
 

--- a/resources/webix_widgets/xenv_hq_main_view.js
+++ b/resources/webix_widgets/xenv_hq_main_view.js
@@ -156,14 +156,14 @@ const main = webix.protoUI({
     },
     $init(config){
         webix.extend(config, this._ui());
-        webix.extend(config, {
-            rest: PlatformContext.rest,
-            host: "localhost/10000",
-            device: "development/xenv/configuration"
-        });
 
+        OpenAjax.hub.subscribe(`ConfigurationManager.set.proxy`,(eventName,{server})=>{
+            webix.extend(this.config, {
+                rest: PlatformContext.rest,
+                host: server.device.host.id.replace(':','/'),
+                device: server.ver
+            });
 
-        this.$ready.push(() => {
             this.$$('listDataSources').load(newTangoAttributeProxy(this.config.rest, this.config.host, this.config.device, "datasourcecollections"))
         });
     }

--- a/resources/webix_widgets/xenv_hq_main_view.js
+++ b/resources/webix_widgets/xenv_hq_main_view.js
@@ -33,28 +33,11 @@ const dataSourcesView = {
                 }
             },
             on: {
-                onItemClick(id){
-                    // if(this.getSelectedId() === id){
-                    //     this.unselectAll();
-                    // } else {
-                    //     this.select(id);
-                    // }
-                },
-                onBlur(){
-                    // const $$hq = this.getTopParentView().getTopParentView();
-                    // $$hq.pushConfiguration();
-                },
-                onAfterAdd: function (obj) {
-                    // const $$hq = this.getTopParentView();
-                    // $$hq.addDataSource(this.getItem(obj));
-                },
-                onDataUpdate: function (obj) {
-                    // const $$hq = this.getTopParentView();
-                    // $$hq.addDataSource(this.getItem(obj));
-                },
-                onBeforeDelete: function (obj) {
-                    // const $$hq = this.getTopParentView();
-                    // $$hq.removeDataSource(this.getItem(obj));
+                /**
+                 * tick checkboxes
+                 */
+                onAfterLoad(){
+                    this.getTopParentView().applyProfile(this.getTopParentView().getTopParentView().profile.getValues());
                 }
             }
         }
@@ -153,6 +136,19 @@ const main = webix.protoUI({
         });
         this.$$('listCollections').refresh();
     },
+    prepareCollections(){
+        const result = {
+            lvalue:[],
+            svalue:[]
+        };
+
+        this.data.data.each(item => {
+            result.svalue.push(item.id);
+            result.lvalue.push(item.markCheckbox);
+        });
+
+        return result;
+    },
     run:function(){
         this.servers.data.each(async server => {
             let state, status;
@@ -174,6 +170,14 @@ const main = webix.protoUI({
 
             this.$$('listCollections').load(newTangoAttributeProxy(PlatformContext.rest, this.config.host, this.config.device, "datasourcecollections"))
         });
+    },
+    defaults:{
+        on:{
+            onViewShow(){
+                if(this.config.configurationManager.device == null) return;
+                this.$$('listCollections').load(newTangoAttributeProxy(PlatformContext.rest, this.config.host, this.config.device, "datasourcecollections"))
+            }
+        }
     }
 }, TangoWebappPlatform.mixin.Runnable, webix.ProgressBar, webix.IdSpace, webix.ui.layout);
 

--- a/resources/webix_widgets/xenv_hq_main_view.js
+++ b/resources/webix_widgets/xenv_hq_main_view.js
@@ -13,7 +13,7 @@ const dataSourcesView = {
         newSearch("listDataSources", "#value#"),
         {
             view: "list",
-            id: "listDataSources",
+            id: "listCollections",
             select:true,
             multiselect: true,
             template:
@@ -138,11 +138,19 @@ const main = webix.protoUI({
         return this.$$('listServers');
     },
     get data(){
-        return this.$$('listDataSources');
+        return this.$$('listCollections');
     },
-    clearAll(){
-        this.$$('listDataSources').clearAll();
-        this.$$('frmDataSource').clear();
+    applyProfile(profile){
+        this.data.data.each(item => {
+            item.markCheckbox = profile.collections[item.id];
+        });
+        this.data.refresh();
+    },
+    resetDataSources(){
+        this.$$('listCollections').data.each(item => {
+            item.markCheckbox = 0;
+        });
+        this.$$('listCollections').refresh();
     },
     run:function(){
         this.servers.data.each(async server => {
@@ -159,12 +167,11 @@ const main = webix.protoUI({
 
         OpenAjax.hub.subscribe(`ConfigurationManager.set.proxy`,(eventName,{server})=>{
             webix.extend(this.config, {
-                rest: PlatformContext.rest,
                 host: server.device.host.id.replace(':','/'),
                 device: server.ver
             });
 
-            this.$$('listDataSources').load(newTangoAttributeProxy(this.config.rest, this.config.host, this.config.device, "datasourcecollections"))
+            this.$$('listCollections').load(newTangoAttributeProxy(PlatformContext.rest, this.config.host, this.config.device, "datasourcecollections"))
         });
     }
 }, TangoWebappPlatform.mixin.Runnable, webix.ProgressBar, webix.IdSpace, webix.ui.layout);

--- a/resources/webix_widgets/xenv_hq_main_view.js
+++ b/resources/webix_widgets/xenv_hq_main_view.js
@@ -7,7 +7,7 @@ const dataSourcesView = {
     padding: 15,
     rows: [
         {
-            template: "Nexus file data sources",
+            template: "Nexus file data source collections",
             type: "header"
         },
         newSearch("listDataSources", "#value#"),
@@ -30,6 +30,16 @@ const dataSourcesView = {
                     const item = this.getItem(id);
                     item.markCheckbox = item.markCheckbox?0:1;
                     this.updateItem(id, item);
+                    //update profile on the client side
+                    //TODO refactor
+                    const profile = this.getTopParentView().getTopParentView()
+                        .profile.getValues();
+                    const collection = profile.configuration.collections.find(collection => collection.id === id);
+                    if(collection !== undefined) collection.value = item.markCheckbox;
+                    else profile.configuration.collections.push({
+                        id,
+                        value: item.markCheckbox
+                    });
                 }
             },
             on: {
@@ -125,9 +135,10 @@ const main = webix.protoUI({
     },
     applyProfile(profile){
         profile.configuration.collections.forEach(collection => {
-            this.data.updateItem(collection.id,{
-                markCheckbox: collection.value
-            })
+            if(this.data.getItem(collection.id) !== undefined)
+                this.data.updateItem(collection.id,{
+                    markCheckbox: collection.value
+                });
         });
     },
     resetDataSources(){

--- a/resources/webix_widgets/xenv_hq_main_view.js
+++ b/resources/webix_widgets/xenv_hq_main_view.js
@@ -141,10 +141,11 @@ const main = webix.protoUI({
         return this.$$('listCollections');
     },
     applyProfile(profile){
-        this.data.data.each(item => {
-            item.markCheckbox = profile.collections[item.id];
+        profile.configuration.collections.forEach(collection => {
+            this.data.updateItem(collection.id,{
+                markCheckbox: collection.value
+            })
         });
-        this.data.refresh();
     },
     resetDataSources(){
         this.$$('listCollections').data.each(item => {

--- a/resources/webix_widgets/xenv_models.js
+++ b/resources/webix_widgets/xenv_models.js
@@ -29,7 +29,8 @@ export class DataSource {
         }
     }
 
-    constructor(src, nxPath, type, pollRate, dataType) {
+    constructor(id, src, nxPath, type, pollRate, dataType) {
+        this.id = id;
         this.src = src;
         this.nxPath = nxPath;
         this.type = type;

--- a/resources/webix_widgets/xenv_views.js
+++ b/resources/webix_widgets/xenv_views.js
@@ -119,7 +119,7 @@ export const xenvHqToolbar = {
     maxHeight: 30,
     cols: [
         {
-            view: "select",
+            view: "combo",
             id: "profiles",
             label: "Profile",
             options: [],

--- a/resources/webix_widgets/xenv_views.js
+++ b/resources/webix_widgets/xenv_views.js
@@ -1,4 +1,5 @@
 import {newXenvMainBody} from "./xenv_hq_main_view.js";
+import {newDataSourcesBody} from "./xenv_datasources_view.js";
 import {newStatusServerViewBody} from "./xenv_status_server_view.js";
 import {newCamelIntegrationViewBody} from "./xenv_camel_view.js";
 import {newPredatorViewBody} from "./xenv_predator_view.js";
@@ -263,6 +264,10 @@ export function newXenvHqBody(config){
             {
                 header: "Main",
                 body: newXenvMainBody(config)
+            },
+            {
+                header: "DataSources",
+                body: newDataSourcesBody(config)
             },
             {
                 header: "DataFormatServer",


### PR DESCRIPTION
To test new widget one needs to do the following:

**login**

Login with your DESY account. 

> NOTE: General account may be used, but this will affect production stage as well.

**setup**

Add `hzgxenvtest:10000` Tango host (User -> Settings) and expand it.

Drag and drop `test/hq/*`. `test/dfs/0`, `test/camel/0`, `test/predator/0`, `test/status_server/status_server`:

_rmb on the image -> show in new tab to enlarge_

![203-setup](https://user-images.githubusercontent.com/11678364/64608056-1d4dc000-d3ca-11e9-8d6e-c21abed794da.gif)


**create/modify data sources**

> NOTE: old profiles have been converted to new data source collections. You may want to split them.

_rmb on the image -> show in new tab to enlarge_

![203-data_sources](https://user-images.githubusercontent.com/11678364/64608108-3ce4e880-d3ca-11e9-85b9-7ff09bc74dc1.gif)


**restart Xenv**

_rmb on the image -> show in new tab to enlarge_

![203-daq](https://user-images.githubusercontent.com/11678364/64608124-48381400-d3ca-11e9-9979-84da0845f50d.gif)


**check the result**

_rmb on the image -> show in new tab to enlarge_

![203-result](https://user-images.githubusercontent.com/11678364/64608138-4f5f2200-d3ca-11e9-8baa-d95697bdb601.gif)
